### PR TITLE
Minor improvements and wider file support

### DIFF
--- a/app.js
+++ b/app.js
@@ -333,6 +333,7 @@ function handleChange(event) {
     return;
   }
 
+  downloadLink.hidden = true;
   readFile(event.target.files[0]).then(contents => {
     const convertedFile = convertFile(contents);
     updateDownloadLink(createDownloadableUrl(convertedFile));

--- a/app.js
+++ b/app.js
@@ -53,7 +53,7 @@ aa - Same as AA, but works if the "AM" or " PM" strings (space before them inclu
 
 (Eg. for French the date format is: DD/MM/YYYY à HH:mm aa)
 Do you need placeholders for different values? Submit an issue.`,
-    "DD/MM/YY, HH:mm aa"
+    dateFormat
   );
 
   fileAttachedString = prompt(
@@ -69,7 +69,7 @@ You need to copy the version occuring in your export into the field below
 
 (Eg. For French it is "fichier joint")
 `,
-    "file attached"
+    fileAttachedString
   );
 };
 

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ const input = document.getElementById("input");
 const downloadLink = document.getElementById("download-link");
 input.addEventListener("change", handleChange);
 let allow = true;
+var inputFileName;
 
 // Function to read the text file and get the text inside it, returns a Promise so we can use it in handleChange()
 const readFile = file => {
@@ -27,6 +28,7 @@ const createDownloadableUrl = contents => {
 // function to set the downloading link to the button and then make it appear
 const updateDownloadLink = url => {
   downloadLink.href = url;
+  downloadLink.download = inputFileName;
   downloadLink.hidden = false;
 };
 
@@ -317,11 +319,12 @@ function handleChange(event) {
 
   // Extracting the title of the uploaded file to display it instead of "Upload file..."
   if (allow) {
-    var fileName = event.target.value.split("\\").pop();
-    if (fileName)
+    inputFileName = event.target.value.split("\\").pop();
+    if (inputFileName)
       document.getElementsByTagName(
         "label"
-      )[0].innerHTML = `<strong>${fileName}</strong>`;
+      )[0].innerHTML = `<strong>${inputFileName}</strong>`;
+	  inputFileName = inputFileName.substring(0, inputFileName.lastIndexOf(".txt")) + ".html"; //Replace the .txt extension for the output file
   }
 
   if (!event.target.files || !allow) {


### PR DESCRIPTION
I was using this app "for real" today (meaning I was parsing real chats and not just tests) and I found a few flaws and also got a few ideas for improvements, so I implemented them.

Changes:
- When the input prompts are displayed, they already contain the current values
- The name of the output file is the same as the name of the input file (apart from the extension) - this makes it possible to convert multiple files after each other without making a mess in the "Downloads" folder
- The download button now hides again, while the next file is being processed (so the user doesn't accidentally download the previous output)
- Many new file extensions of media files are now supported (this includes e. g. the format used for stickers)
- Non-media files are now supported too - here is how it looks like in the output:
![image](https://user-images.githubusercontent.com/19894267/106795989-0fea4300-665b-11eb-8a61-f376a8ba27df.png)

There are a few other things that I might want to change (such as choosing the name of user whose messages will be darker), but it can wait. Maybe I make time for that somewhen.